### PR TITLE
Use Dropbox Debian package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ USER root
 COPY run /root
 RUN chmod +x /root/run 
 
-CMD ["/dbox/run"]
+CMD ["/root/run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,33 +2,33 @@ FROM debian:jessie
 MAINTAINER Jan Broer <janeczku@yahoo.de>
 ENV DEBIAN_FRONTEND noninteractive
 
-# Download & install required applications: curl.
+# Following 'How do I add or remove Dropbox from my Linux repository?' - https://www.dropbox.com/en/help/246
+RUN echo 'deb http://linux.dropbox.com/debian jessie main' > /etc/apt/sources.list.d/dropbox.list
+RUN apt-key adv --keyserver pgp.mit.edu --recv-keys 1C61A2656FB57B7E4DE0F4C1FC918B335044912E
 RUN apt-get -qqy update
-RUN apt-get -qqy install wget python
-
-# Create service account and set permissions.
-RUN groupadd dropbox
-RUN useradd -d /dbox -c "Dropbox Daemon Account" -s /usr/sbin/nologin -g dropbox dropbox
-RUN mkdir -p /dbox/.dropbox /dbox/.dropbox-dist /dbox/Dropbox /dbox/base
-
-# Download & install Dropbox 3.2.9 and latest python client
-RUN wget -nv -O /dbox/base/dropbox.tar.gz "https://github.com/radio-astro/docker-dropbox/blob/master/dropbox-lnx.x86_64-3.2.9.tar.gz?raw=true"
-RUN wget -nv -O /dbox/dropbox.py "https://www.dropbox.com/download?dl=packages/dropbox.py"
-
+# Note 'ca-certificates' dependency is required for 'dropbox start -i' to succeed
+RUN apt-get -qqy install ca-certificates dropbox
 # Perform image clean up.
 RUN apt-get -qqy autoclean
 
-# Set permissions
-RUN chown -R dropbox:dropbox /dbox
-
-# Install script for managing dropbox init.
-COPY run /dbox/
-COPY dropbox /usr/local/bin/
-RUN chmod +x /dbox/run /usr/local/bin/dropbox /dbox/dropbox.py
-
-VOLUME ["/dbox/.dropbox", "/dbox/.dropbox-dist", "/dbox/Dropbox"]
+# Create service account and set permissions.
+RUN groupadd dropbox
+RUN useradd -m -d /dbox -c "Dropbox Daemon Account" -s /usr/sbin/nologin -g dropbox dropbox
 
 # Dropbox Lan-sync
 EXPOSE 17500
+VOLUME ["/dbox/Dropbox"]
+
+# Dropbox is weird: it insists on downloading its biniaries itself via 'dropbox
+# start -i'. So we switch to 'dropbox' user temporarily and let it do its thing.
+USER dropbox
+RUN mkdir -p /dbox/.dropbox /dbox/.dropbox-dist /dbox/Dropbox /dbox/base
+RUN echo y | dropbox start -i
+
+# Switch back to root, since the run script needs root privs to chmod to the user's preferrred UID
+USER root
+### Install script for managing dropbox init.
+COPY run /root
+RUN chmod +x /root/run 
 
 CMD ["/dbox/run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN useradd -m -d /dbox -c "Dropbox Daemon Account" -s /usr/sbin/nologin -g drop
 
 # Dropbox Lan-sync
 EXPOSE 17500
-VOLUME ["/dbox/Dropbox"]
+VOLUME ["/dbox/.dropbox", "/dbox/Dropbox"]
 
 # Dropbox is weird: it insists on downloading its biniaries itself via 'dropbox
 # start -i'. So we switch to 'dropbox' user temporarily and let it do its thing.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM debian:jessie
 MAINTAINER Jan Broer <janeczku@yahoo.de>
 ENV DEBIAN_FRONTEND noninteractive
 
-# Download & install required applications: curl, sudo.
+# Download & install required applications: curl.
 RUN apt-get -qqy update
-RUN apt-get -qqy install wget python sudo
+RUN apt-get -qqy install wget python
 
 # Create service account and set permissions.
 RUN groupadd dropbox

--- a/README.md
+++ b/README.md
@@ -60,8 +60,5 @@ Set the owner of the Dropbox folder to a custom GID
 
 ## Exposed volumes
 
-`/dbox/.dropbox` 
-Dropbox config folder
-
 `/dbox/Dropbox`
 Dropbox files

--- a/run
+++ b/run
@@ -36,12 +36,6 @@ chmod 755 /dbox/Dropbox
 [ ! -e "/dbox/.dropbox/unlink.db" ]      || rm /dbox/.dropbox/unlink.db
 [ ! -e "/dbox/.dropbox/dropbox.pid" ]    || rm /dbox/.dropbox/dropbox.pid
 
-# Dropbox is not already extracted?
-if [ ! -f "/dbox/.dropbox-dist/dropboxd" ]; then
-	tar -xzf /dbox/base/dropbox.tar.gz -C /dbox/
-	chown -R $DBOX_UID:$DBOX_GID /dbox/.dropbox-dist
-fi
-
 echo "dropboxd($(cat /dbox/.dropbox-dist/VERSION)) started..."
 umask 002
 exec su dropbox -s /bin/bash -c /dbox/.dropbox-dist/dropboxd

--- a/run
+++ b/run
@@ -22,7 +22,7 @@ if [ -z "$FIND_GROUP" ]; then
 fi
 
 # Set dropbox account's UID.
-usermod -u $DBOX_UID -g $DBOX_GID dropbox > /dev/null 2>&1
+usermod -u $DBOX_UID -g $DBOX_GID --non-unique dropbox > /dev/null 2>&1
 
 # Change ownership to dropbox account on all working folders.
 chown -R $DBOX_UID:$DBOX_GID /dbox

--- a/run
+++ b/run
@@ -44,4 +44,4 @@ fi
 
 echo "dropboxd($(cat /dbox/.dropbox-dist/VERSION)) started..."
 umask 002
-exec sudo -u dropbox /dbox/.dropbox-dist/dropboxd
+exec su dropbox -s /bin/bash -c /dbox/.dropbox-dist/dropboxd


### PR DESCRIPTION
Hi,

Thanks for publishing your docker-dropbox Dockerfile! I took it and made some of what I hope are improvements, which you might like to incorporate:

1.  Your Dockerfile obtains Dropbox from https://github.com/radio-astro/docker-dropbox/blob/master/dropbox-lnx.x86_64-3.2.9.tar.gz?raw=true. This is an old version (3.2.9 vs. current 3.10.11) that has been giving me warnings:

    ""You're using an old version of Dropbox. Please update within the next 27 days to continue using Dropbox""

  I have changed the Dockerfile to install the latest Dropbox from dropbox.com, so that it will be always up-to-date.

The other changes are minor:

2. Support for setting DBOX_UID to 0 or any other UID already defined in /etc/passwd. Previously setting DBOX_UID=0 would fail because the 'usermod' in /run didn't like changing the 'dropbox' UID to the same as root. I added '--non-unique' to the usermod to fix this.

3. Replaced use of 'sudo -u dropbox' with 'su - dropbox'. I don't actually know if this was a good idea - does sudo provide some security advantage I'm unaware of?

4. Removed '/dbox/.dropbox-dist' from the VOLUME set. I figured there is nothing in there the host should care about (if I'm wrong I'd be interested to know why).

5. Moved /dbox/run to /root/run, as it seemed more correct since 'run' runs as root, not 'dropbox'.

Thanks again.