### PR TITLE
Fix build problem when using docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,6 @@ RUN apt-get -qqy autoclean
 RUN groupadd dropbox
 RUN useradd -m -d /dbox -c "Dropbox Daemon Account" -s /usr/sbin/nologin -g dropbox dropbox
 
-# Dropbox Lan-sync
-EXPOSE 17500
-VOLUME ["/dbox/.dropbox", "/dbox/Dropbox"]
-
 # Dropbox is weird: it insists on downloading its biniaries itself via 'dropbox
 # start -i'. So we switch to 'dropbox' user temporarily and let it do its thing.
 USER dropbox
@@ -30,5 +26,11 @@ USER root
 ### Install script for managing dropbox init.
 COPY run /root
 RUN chmod +x /root/run 
+
+# Dropbox Lan-sync
+EXPOSE 17500
+
+# Expose the .dropbox/ runtime status and Dropbox/ content files. This comes After 'dropbox start -i' in case the builder was 'docker-compose build', which mounts these and so can cause permission errors.
+VOLUME ["/dbox/.dropbox", "/dbox/Dropbox"]
 
 CMD ["/root/run"]


### PR DESCRIPTION
Hi,

Please find linked a `Dockerfile` patch that simply moves the VOLUME and EXPOSE to the end.

This is necessary if building with `docker-compose build` (rather than the usual `docker build`) with a `docker-compose.yml` containing volumes, as in [this example](https://github.com/redradishtech/dropbox_to_s3_syncer/blob/master/docker-compose.yml)). For some reason `docker-compose build` mounts the volumes, including `/dbox/.dropbox-dist`. The Dockerfile isn't expecting stuff in `/dbox/.dropbox-dist`, and so when it gets to the `dropbox start -i` step, it fails with permission errors. 

The fix is simply to put the VOLUME mount at the end, after the `dropbox start -i`. 

(PS: Thanks for merging my last pull request. Your changes all work nicely for me.)