### PR TITLE
Install python-gpgme so dropbox can verify its binary download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN echo 'deb http://linux.dropbox.com/debian jessie main' > /etc/apt/sources.li
 	&& apt-key adv --keyserver pgp.mit.edu --recv-keys 1C61A2656FB57B7E4DE0F4C1FC918B335044912E \
 	&& apt-get -qqy update \
 	# Note 'ca-certificates' dependency is required for 'dropbox start -i' to succeed
-	&& apt-get -qqy install ca-certificates curl dropbox \
+	&& apt-get -qqy install ca-certificates curl python-gpgme dropbox \
 	# Perform image clean up.
 	&& apt-get -qqy autoclean \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
We need to trust Dropbox (well, not really, that's why we're running
it in a Docker container :-), but we shouldn't need to trust any
random FBI or KGB agent trying to carry out a man-in-the-middle
attack.

Signed-off-by: Theodore Ts'o tytso@mit.edu
