### PR TITLE
Don't try to update Dropbox if the download failed

### DIFF
--- a/run
+++ b/run
@@ -53,12 +53,16 @@ if [[ -z "$DBOX_SKIP_UPDATE" ]]; then
 	if [ ! -z "${Latest}" ] && [ ! -z "${Current}" ] && [ $Current != $Latest ]; then
 	        echo "Downloading Dropbox v$Latest..."
 	        tmpdir=`mktemp -d`
-	        curl -# -L $DL | tar xzf - -C $tmpdir
-	        echo "Installing new version..."
-	        rm -rf /opt/dropbox/*
-	        mv $tmpdir/.dropbox-dist/* /opt/dropbox/
-	        rm -rf $tmpdir
-	        echo "Dropbox updated to v$Latest"
+                (curl -# -L $DL | tar xzf - -C $tmpdir) || rm -rf $tmpdir
+                if [ -d $tmpdir ]; then
+                    echo "Installing new version..."
+                    rm -rf /opt/dropbox/*
+                    mv $tmpdir/.dropbox-dist/* /opt/dropbox/
+                    rm -rf $tmpdir
+                    echo "Dropbox updated to v$Latest"
+                else
+                    echo "Download failed"
+                fi
 	else
 		echo "Dropbox is up-to-date"
 	fi


### PR DESCRIPTION
Otherwise you could end up with this situation, repeated forever:

curl: (56) SSL read: error:00000000:lib(0):func(0):reason(0), errno 104

gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
Installing new version...
Dropbox updated to v55.4.171
cat: /opt/dropbox/VERSION: No such file or directory
Starting dropboxd ()...
bash: /opt/dropbox/dropboxd: No such file or directory
Checking for latest Dropbox version...
cat: /opt/dropbox/VERSION: No such file or directory
Latest   : 55.4.171
Installed:
Dropbox is up-to-date
cat: /opt/dropbox/VERSION: No such file or directory
Starting dropboxd ()...
bash: /opt/dropbox/dropboxd: No such file or directory
Checking for latest Dropbox version...
cat: /opt/dropbox/VERSION: No such file or directory
Latest   : 55.4.171
Installed:
Dropbox is up-to-date
…