### PR TITLE
Add this feature to stop dropbox from not working anymore in 2 weeks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dropbox_ext4"]
+	path = dropbox_ext4
+	url = https://github.com/djrodgerspryor/dropbox_ext4.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "dropbox_ext4"]
-	path = dropbox_ext4
-	url = https://github.com/djrodgerspryor/dropbox_ext4.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,63 @@
 FROM debian:jessie
-MAINTAINER Jan Broer <janeczku@yahoo.de>
+MAINTAINER Daniel Rodgers-Pryor <djrodgerspryor@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 # Following 'How do I add or remove Dropbox from my Linux repository?' - https://www.dropbox.com/en/help/246
 RUN echo 'deb http://linux.dropbox.com/debian jessie main' > /etc/apt/sources.list.d/dropbox.list \
-	&& apt-key adv --keyserver pgp.mit.edu --recv-keys 1C61A2656FB57B7E4DE0F4C1FC918B335044912E \
-	&& apt-get -qqy update \
-	# Note 'ca-certificates' dependency is required for 'dropbox start -i' to succeed
-	&& apt-get -qqy install ca-certificates curl python-gpgme dropbox \
-	# Perform image clean up.
-	&& apt-get -qqy autoclean \
-	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-	# Create service account and set permissions.
-	&& groupadd dropbox \
-	&& useradd -m -d /dbox -c "Dropbox Daemon Account" -s /usr/sbin/nologin -g dropbox dropbox
+    && apt-key adv --keyserver pgp.mit.edu --recv-keys 1C61A2656FB57B7E4DE0F4C1FC918B335044912E \
+    && apt-get -qqy update \
+    # Note 'ca-certificates' dependency is required for 'dropbox start -i' to succeed
+    && apt-get -qqy install ca-certificates curl python-gpgme dropbox python3 \
+    # Perform image clean up.
+    && apt-get -qqy autoclean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    # Create service account and set permissions.
+    && groupadd dropbox \
+    && useradd -m -d /dbox -c "Dropbox Daemon Account" -s /usr/sbin/nologin -g dropbox dropbox
 
 # Dropbox is weird: it insists on downloading its binaries itself via 'dropbox
 # start -i'. So we switch to 'dropbox' user temporarily and let it do its thing.
 USER dropbox
 RUN mkdir -p /dbox/.dropbox /dbox/.dropbox-dist /dbox/Dropbox /dbox/base \
-	&& echo y | dropbox start -i
+    && echo y | dropbox start -i
 
 # Switch back to root, since the run script needs root privs to chmod to the user's preferrred UID
 USER root
+
+# Install dropbox files-system support patch
+ADD ./dropbox_ext4/* /tmp/dropbox_ext4/
+WORKDIR /tmp/dropbox_ext4
+RUN ./fix_dropbox.py \
+    && cd .. \
+    && rm -rf /tmp/dropbox_ext4
+WORKDIR /
 
 # Dropbox has the nasty tendency to update itself without asking. In the processs it fills the
 # file system over time with rather large files written to /dbox and /tmp. The auto-update routine
 # also tries to restart the dockerd process (PID 1) which causes the container to be terminated.
 RUN mkdir -p /opt/dropbox \
-	# Prevent dropbox to overwrite its binary
-	&& mv /dbox/.dropbox-dist/dropbox-lnx* /opt/dropbox/ \
-	&& mv /dbox/.dropbox-dist/dropboxd /opt/dropbox/ \
-	&& mv /dbox/.dropbox-dist/VERSION /opt/dropbox/ \
-	&& rm -rf /dbox/.dropbox-dist \
-	&& install -dm0 /dbox/.dropbox-dist \
-	# Prevent dropbox to write update files
-	&& chmod u-w /dbox \
-	&& chmod o-w /tmp \
-	&& chmod g-w /tmp \
-	# Prepare for command line wrapper
-	&& mv /usr/bin/dropbox /usr/bin/dropbox-cli
+    # Prevent dropbox to overwrite its binary
+    && mv /dbox/.dropbox-dist/dropbox-lnx* /opt/dropbox/ \
+    && mv /dbox/.dropbox-dist/dropboxd /opt/dropbox/ \
+    && mv /dbox/.dropbox-dist/VERSION /opt/dropbox/ \
+    && rm -rf /dbox/.dropbox-dist \
+    && install -dm0 /dbox/.dropbox-dist \
+    # Prevent dropbox to write update files
+    && chmod u-w /dbox \
+    && chmod o-w /tmp \
+    && chmod g-w /tmp \
+    # Prepare for command line wrapper
+    && mv /usr/bin/dropbox /usr/bin/dropbox-cli
 
 # Install init script and dropbox command line wrapper
 COPY run /root/
 COPY dropbox /usr/bin/dropbox
+
+# Assert that dropbox points at the wrapper script set-up by the dropbox_ext4 patch, which set's the
+# LD_PRELOAD path properly. The run script executes `dropbox` not `/usr/bin/dropbox`, so this means that the
+# actual execution order will be:
+#     /root/run -> /usr/local/bin/dropbox -> /usr/bin/dropbox -> /usr/bin/dropbox-cli
+RUN [ "$(which dropbox)" = "/usr/local/bin/dropbox" ]
 
 WORKDIR /dbox/Dropbox
 EXPOSE 17500

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,6 @@ RUN mkdir -p /dbox/.dropbox /dbox/.dropbox-dist /dbox/Dropbox /dbox/base \
 # Switch back to root, since the run script needs root privs to chmod to the user's preferrred UID
 USER root
 
-# Install dropbox files-system support patch
-ADD ./dropbox_ext4/* /tmp/dropbox_ext4/
-WORKDIR /tmp/dropbox_ext4
-RUN ./fix_dropbox.py \
-    && cd .. \
-    && rm -rf /tmp/dropbox_ext4
-WORKDIR /
-
 # Dropbox has the nasty tendency to update itself without asking. In the processs it fills the
 # file system over time with rather large files written to /dbox and /tmp. The auto-update routine
 # also tries to restart the dockerd process (PID 1) which causes the container to be terminated.
@@ -52,12 +44,6 @@ RUN mkdir -p /opt/dropbox \
 # Install init script and dropbox command line wrapper
 COPY run /root/
 COPY dropbox /usr/bin/dropbox
-
-# Assert that dropbox points at the wrapper script set-up by the dropbox_ext4 patch, which set's the
-# LD_PRELOAD path properly. The run script executes `dropbox` not `/usr/bin/dropbox`, so this means that the
-# actual execution order will be:
-#     /root/run -> /usr/local/bin/dropbox -> /usr/bin/dropbox -> /usr/bin/dropbox-cli
-RUN [ "$(which dropbox)" = "/usr/local/bin/dropbox" ]
 
 WORKDIR /dbox/Dropbox
 EXPOSE 17500

--- a/README.md
+++ b/README.md
@@ -1,25 +1,24 @@
 # Dropbox in Docker
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/janeczku/dropbox.svg?maxAge=2592000)][hub]
-[![License](https://img.shields.io/github/license/janeczku/docker-alpine-kubernetes.svg?maxAge=2592000)]()
-
-[hub]: https://hub.docker.com/r/janeczku/dropbox/
+[hub]: https://hub.docker.com/r/drodgers/dropbox/
 
 Run Dropbox inside Docker. Fully working with local host folder mount or inter-container linking (via `--volumes-from`).
 
-This repository provides the [janeczku/dropbox](https://registry.hub.docker.com/u/janeczku/dropbox/) image.
+This repository provides the [drodgers/dropbox](https://registry.hub.docker.com/u/drodgers/dropbox/) image.
+
+Forked from https://github.com/janeczku/docker-dropbox to add [dimaryaz's patch](https://github.com/dimaryaz/dropbox_ext4) to keep dropbox working on non-ext4 filesystems.
 
 ## Usage examples
 
 ### Quickstart
 
-    docker run -d --restart=always --name=dropbox janeczku/dropbox
+    docker run -d --restart=always --name=dropbox drodgers/dropbox
 
 ### Dropbox data mounted to local folder on the host
 
     docker run -d --restart=always --name=dropbox \
     -v /path/to/localfolder:/dbox/Dropbox \
-    janeczku/dropbox
+    drodgers/dropbox
 
 ### Run dropbox with custom user/group id
 This fixes file permission errrors that might occur when mounting the Dropbox file folder (`/dbox/Dropbox`) from the host or a Docker container volume. You need to set `DBOX_UID`/`DBOX_GID` to the user id and group id of whoever owns these files on the host or in the other container.
@@ -27,13 +26,13 @@ This fixes file permission errrors that might occur when mounting the Dropbox fi
     docker run -d --restart=always --name=dropbox \
     -e DBOX_UID=110 \
     -e DBOX_GID=200 \
-    janeczku/dropbox
+    drodgers/dropbox
 
 ### Enable LAN Sync
 
     docker run -d --restart=always --name=dropbox \
     --net="host" \
-    janeczku/dropbox
+    drodgers/dropbox
 
 ## Linking to Dropbox account after first start
 


### PR DESCRIPTION
Starting november 9th, Dropbox will only support ext4 filesystems on Linux. This feature seems to fix this. 