### PR TITLE
Added a setting for fsnotify watchers and correct install issue for dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,44 +2,17 @@ FROM debian:jessie
 MAINTAINER Jan Broer <janeczku@yahoo.de>
 ENV DEBIAN_FRONTEND noninteractive
 
-# Following 'How do I add or remove Dropbox from my Linux repository?' - https://www.dropbox.com/en/help/246
-RUN echo 'deb http://linux.dropbox.com/debian jessie main' > /etc/apt/sources.list.d/dropbox.list \
-	&& apt-key adv --keyserver pgp.mit.edu --recv-keys 1C61A2656FB57B7E4DE0F4C1FC918B335044912E \
-	&& apt-get -qqy update \
-	# Note 'ca-certificates' dependency is required for 'dropbox start -i' to succeed
-	&& apt-get -qqy install ca-certificates curl python-gpgme dropbox \
-	# Perform image clean up.
-	&& apt-get -qqy autoclean \
-	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-	# Create service account and set permissions.
+# Following https://www.dropbox.com/install?os=lnx
+RUN apt-get update; apt-get install -y curl python \
+    && tmpdir=`mktemp -d` \
+	&& curl -# -L https://www.dropbox.com/download?plat=lnx.x86_64 | tar xzf - -C $tmpdir \
+	&& mkdir /opt/dropbox \
+	&& mv $tmpdir/.dropbox-dist/* /opt/dropbox/ \
+	&& rm -rf $tmpdir \
+	&& curl -L https://www.dropbox.com/download?dl=packages/dropbox.py > /usr/bin/dropbox-cli \
+	&& chmod +x /usr/bin/dropbox-cli \
 	&& groupadd dropbox \
 	&& useradd -m -d /dbox -c "Dropbox Daemon Account" -s /usr/sbin/nologin -g dropbox dropbox
-
-# Dropbox is weird: it insists on downloading its binaries itself via 'dropbox
-# start -i'. So we switch to 'dropbox' user temporarily and let it do its thing.
-USER dropbox
-RUN mkdir -p /dbox/.dropbox /dbox/.dropbox-dist /dbox/Dropbox /dbox/base \
-	&& echo y | dropbox start -i
-
-# Switch back to root, since the run script needs root privs to chmod to the user's preferrred UID
-USER root
-
-# Dropbox has the nasty tendency to update itself without asking. In the processs it fills the
-# file system over time with rather large files written to /dbox and /tmp. The auto-update routine
-# also tries to restart the dockerd process (PID 1) which causes the container to be terminated.
-RUN mkdir -p /opt/dropbox \
-	# Prevent dropbox to overwrite its binary
-	&& mv /dbox/.dropbox-dist/dropbox-lnx* /opt/dropbox/ \
-	&& mv /dbox/.dropbox-dist/dropboxd /opt/dropbox/ \
-	&& mv /dbox/.dropbox-dist/VERSION /opt/dropbox/ \
-	&& rm -rf /dbox/.dropbox-dist \
-	&& install -dm0 /dbox/.dropbox-dist \
-	# Prevent dropbox to write update files
-	&& chmod u-w /dbox \
-	&& chmod o-w /tmp \
-	&& chmod g-w /tmp \
-	# Prepare for command line wrapper
-	&& mv /usr/bin/dropbox /usr/bin/dropbox-cli
 
 # Install init script and dropbox command line wrapper
 COPY run /root/

--- a/run
+++ b/run
@@ -12,6 +12,14 @@ if [ -z "$DBOX_GID" ]; then
 	echo "DBOX_GID variable not specified, defaulting to dropbox user group id ($DBOX_GID)"
 fi
 
+# Set Max Workers for fsnotify
+if [ -z "$MAX_USER_WATCHES" ]; then
+	echo "max_user_watchers left at default"
+else
+	echo fs.inotify.max_user_watches=${MAX_USER_WATCHES} | tee -a /etc/sysctl.conf; sysctl -p
+	echo "Setting fs.inotify.max_user_watches to ${MAX_USER_WATCHES}"
+fi
+
 # Look for existing group, if not found create dropbox with specified GID.
 FIND_GROUP=$(grep ":$DBOX_GID:" /etc/group)
 


### PR DESCRIPTION
I added a setting for the number of fsnotify watchers which is required when there is a dropbox folder with many files, this does require running the container in privileged mode but it does solve the error.

I changed the install pattern in the dockerfile to be more consistent with the install that is done as part of the update in the run script. Using the repo was failing consistently since i was unable to get passed the gpg pulling stage, so this bypasses that need completely and it removes some complexity from the dockerfile.