### PR TITLE
Update to use Debian Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER Jan Broer <janeczku@yahoo.de>
 ENV DEBIAN_FRONTEND noninteractive
 
-# Following 'How do I add or remove Dropbox from my Linux repository?' - https://www.dropbox.com/en/help/246
-RUN echo 'deb http://linux.dropbox.com/debian jessie main' > /etc/apt/sources.list.d/dropbox.list \
-	&& apt-key adv --keyserver pgp.mit.edu --recv-keys 1C61A2656FB57B7E4DE0F4C1FC918B335044912E \
+# From 'How do I add or remove Dropbox from my Linux repository?' -
+# https://www.dropbox.com/en/help/246
+
+RUN apt-get -qqy update \
+  && apt-get -qqy upgrade \
+  && apt-get -qqy install gnupg ca-certificates curl python-gpgme python3-gpg \
+  && echo 'deb http://linux.dropbox.com/debian stretch main' > /etc/apt/sources.list.d/dropbox.list \
+	&& apt-key adv --keyserver ipv4.pool.sks-keyservers.net --recv-keys 1C61A2656FB57B7E4DE0F4C1FC918B335044912E \
 	&& apt-get -qqy update \
 	# Note 'ca-certificates' dependency is required for 'dropbox start -i' to succeed
-	&& apt-get -qqy install ca-certificates curl python-gpgme dropbox \
+	&& apt-get -qqy install dropbox \
 	# Perform image clean up.
 	&& apt-get -qqy autoclean \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
Debian Jessie (now old stable) is not getting security updates any
more, and is in general no longer supported.  So update to use Debian
Stretch.

Signed-off-by: Theodore Ts'o <tytso@mit.edu>