### PR TITLE
Add missing libatomic1 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN echo 'deb http://linux.dropbox.com/debian jessie main' > /etc/apt/sources.li
 	&& apt-key adv --keyserver pgp.mit.edu --recv-keys 1C61A2656FB57B7E4DE0F4C1FC918B335044912E \
 	&& apt-get -qqy update \
 	# Note 'ca-certificates' dependency is required for 'dropbox start -i' to succeed
-	&& apt-get -qqy install ca-certificates curl python-gpgme dropbox \
+	&& apt-get -qqy install ca-certificates curl python-gpgme libatomic1 dropbox \
 	# Perform image clean up.
 	&& apt-get -qqy autoclean \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
This seems to be a new (missed) dependency in the latest version. See https://www.dropboxforum.com/t5/Installs-integrations/I-m-getting-an-error-message-quot-Could-not-start-the-Dropbox/m-p/378979/highlight/true#M83021 for discussions.