### PR TITLE
Fix missing requirements and update to buster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# DEPRECATED - FIND REPLACEMENT BELOW
+
+This repository, much like Docker (both the company and the product) is deprecated.
+
+You will find a much better alternative to this image at: https://github.com/ecnepsnai/podman-docker
+
+Original readme below...
+
+---
+
 # Dropbox in Docker
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/janeczku/dropbox.svg?maxAge=2592000)][hub]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository, much like Docker (both the company and the product) is deprecated.
 
-You will find a much better alternative to this image at: https://github.com/ecnepsnai/podman-docker
+You will find a much better alternative to this image at: https://github.com/ecnepsnai/podman-dropbox
 
 Original readme below...
 


### PR DESCRIPTION
As reported by @dolhop in #46 Dropbox now requires some extra libraries that were missing. This PR adds the missing requirements and updated the base image to buster.